### PR TITLE
Use Rust allocations for XML_ParserStruct and encodings

### DIFF
--- a/src/expat_h.rs
+++ b/src/expat_h.rs
@@ -180,7 +180,7 @@ pub type XML_XmlDeclHandler = Option<
     unsafe extern "C" fn(_: *mut c_void, _: *const XML_Char, _: *const XML_Char, _: c_int) -> (),
 >;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct XML_Memory_Handling_Suite {
     pub malloc_fcn: Option<unsafe extern "C" fn(_: size_t) -> *mut c_void>,
     pub realloc_fcn: Option<unsafe extern "C" fn(_: *mut c_void, _: size_t) -> *mut c_void>,
@@ -405,7 +405,7 @@ pub const XML_PARSING: XML_Parsing = 1;
 pub const XML_FINISHED: XML_Parsing = 2;
 pub const XML_SUSPENDED: XML_Parsing = 3;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct XML_ParsingStatus {
     pub parsing: XML_Parsing,
     pub finalBuffer: XML_Bool,

--- a/src/lib/xmlrole.rs
+++ b/src/lib/xmlrole.rs
@@ -104,7 +104,7 @@ pub const XML_ROLE_PARAM_ENTITY_REF: C2RustUnnamed_0 = 60;
 pub type PROLOG_STATE = prolog_state;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct prolog_state {
     pub handler: Option<
         unsafe extern "C" fn(

--- a/src/tests/runtests.rs
+++ b/src/tests/runtests.rs
@@ -16153,7 +16153,7 @@ unsafe extern "C" fn test_misc_alloc_create_parser() {
         allocation_count = i as intptr_t;
         g_parser = XML_ParserCreate_MM(
             ::expat_rs::stddef_h::NULL as *const XML_Char,
-            &mut memsuite as *mut _ as *const XML_Memory_Handling_Suite,
+            Some(&memsuite),
             ::expat_rs::stddef_h::NULL as *const XML_Char,
         );
         if !g_parser.is_null() {
@@ -16209,7 +16209,7 @@ unsafe extern "C" fn test_misc_alloc_create_parser_with_encoding() {
         allocation_count = i as intptr_t;
         g_parser = XML_ParserCreate_MM(
             b"us-ascii\x00".as_ptr() as *const c_char,
-            &mut memsuite as *mut _ as *const XML_Memory_Handling_Suite,
+            Some(&memsuite),
             ::expat_rs::stddef_h::NULL as *const XML_Char,
         );
         if !g_parser.is_null() {
@@ -16501,7 +16501,7 @@ unsafe extern "C" fn test_misc_attribute_leak() {
     };
     g_parser = XML_ParserCreate_MM(
         b"UTF-8\x00".as_ptr() as *const c_char,
-        &mut memsuite as *mut _ as *const XML_Memory_Handling_Suite,
+        Some(&memsuite),
         b"\n\x00".as_ptr() as *const c_char,
     );
     _expect_failure(
@@ -16800,7 +16800,7 @@ unsafe extern "C" fn alloc_setup() {
     reallocation_count = REALLOC_ALWAYS_SUCCEED as intptr_t;
     g_parser = XML_ParserCreate_MM(
         ::expat_rs::stddef_h::NULL as *const XML_Char,
-        &mut memsuite as *mut _ as *const XML_Memory_Handling_Suite,
+        Some(&memsuite),
         ::expat_rs::stddef_h::NULL as *const XML_Char,
     );
     if g_parser.is_null() {
@@ -20535,7 +20535,7 @@ unsafe extern "C" fn nsalloc_setup() {
     reallocation_count = REALLOC_ALWAYS_SUCCEED as intptr_t;
     g_parser = XML_ParserCreate_MM(
         ::expat_rs::stddef_h::NULL as *const XML_Char,
-        &mut memsuite as *mut _ as *const XML_Memory_Handling_Suite,
+        Some(&memsuite),
         ns_sep.as_mut_ptr(),
     );
     if g_parser.is_null() {


### PR DESCRIPTION
Also removed the need to pass the encoding everywhere in preparation for making
the encoding field a reference.