### PR TITLE
Refactor wrapping offset from

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(const_raw_ptr_to_usize_cast)]
 #![feature(main)]
 #![feature(const_in_array_repeat_expressions)]
-#![feature(ptr_wrapping_offset_from)]
 #![feature(try_reserve)]
 #![feature(alloc_layout_extra)]
 // Required by !Send and !Sync

--- a/src/lib/xmlparse.rs
+++ b/src/lib/xmlparse.rs
@@ -84,7 +84,7 @@ pub const XML_CONTEXT_BYTES: c_int = 1024;
 pub struct ExpatBufRef<'a, T = c_char>(&'a [T]);
 impl<'a, T> ExpatBufRef<'a, T> {
     pub fn new<'new>(start: *const T, end: *const T) -> ExpatBufRef<'new, T> {
-        unsafe { ExpatBufRef(std::slice::from_raw_parts(start, end.wrapping_offset_from(start) as usize)) }
+        unsafe { ExpatBufRef(std::slice::from_raw_parts(start, ((end as isize) - (start as isize)) as usize)) }
     }
     pub fn new_len<'new>(start: *const T, len: usize) -> ExpatBufRef<'new, T> {
         unsafe { ExpatBufRef(std::slice::from_raw_parts(start, len)) }
@@ -160,7 +160,7 @@ impl<'a> From<ExpatBufRef<'a, c_char>> for ExpatBufRef<'a, c_ushort> {
 pub struct ExpatBufRefMut<'a, T = c_char>(&'a mut [T]);
 impl<'a, T> ExpatBufRefMut<'a, T> {
     pub fn new<'new>(start: *mut T, end: *mut T) -> ExpatBufRefMut<'new, T> {
-        unsafe { ExpatBufRefMut(std::slice::from_raw_parts_mut(start, end.wrapping_offset_from(start) as usize)) }
+        unsafe { ExpatBufRefMut(std::slice::from_raw_parts_mut(start, ((end as isize) - (start as isize)) as usize)) }
     }
     pub fn new_len<'new>(start: *mut T, len: usize) -> ExpatBufRefMut<'new, T> {
         unsafe { ExpatBufRefMut(std::slice::from_raw_parts_mut(start, len)) }
@@ -177,7 +177,7 @@ impl<'a, T> ExpatBufRefMut<'a, T> {
         if new_start < self.as_mut_ptr() || new_start > self.end() {
             panic!("Attempted to move the start of an ExpatBufRefMut to an invalid pointer: {:?}", new_start);
         }
-        let offset = new_start.wrapping_offset_from(self.0.as_ptr());
+        let offset = (new_start as isize) - (self.0.as_ptr() as isize);
         let new_start = unsafe { self.0.as_mut_ptr().offset(offset) };
         *self = ExpatBufRefMut::new(new_start, self.end());
     }
@@ -1014,7 +1014,7 @@ fn safe_ptr_diff<T>(p: *const T, q: *const T) -> isize {
     if p.is_null() || q.is_null() {
         0
     } else {
-        p.wrapping_offset_from(q)
+        (p as isize) - (q as isize)
     }
 }
 
@@ -2826,9 +2826,7 @@ impl XML_ParserStruct {
                         self.m_buffer as *mut c_void,
                         &mut *self.m_buffer.offset(offset as isize) as *mut c_char
                             as *const c_void,
-                        (self
-                            .m_bufferEnd
-                            .wrapping_offset_from(self.m_bufferPtr)
+                        ((self.m_bufferEnd as isize) - (self.m_bufferPtr  as isize)
                             + keep as isize).try_into().unwrap(),
                     );
                     self.m_bufferEnd = self.m_bufferEnd.offset(-offset);
@@ -3066,9 +3064,7 @@ pub unsafe extern "C" fn XML_GetCurrentByteIndex(mut parser: XML_Parser) -> XML_
     }
     if !(*parser).m_eventPtr.is_null() {
         return (*parser).m_parseEndByteIndex
-            - (*parser)
-                .m_parseEndPtr
-                .wrapping_offset_from((*parser).m_eventPtr) as c_long;
+            - ((*parser).m_parseEndPtr as isize - ((*parser).m_eventPtr as isize)) as c_long;
     }
     if cfg!(feature = "mozilla") {
         return (*parser).m_parseEndByteIndex;
@@ -3084,9 +3080,8 @@ pub unsafe extern "C" fn XML_GetCurrentByteCount(mut parser: XML_Parser) -> c_in
         return 0;
     }
     if !(*parser).m_eventEndPtr.is_null() && !(*parser).m_eventPtr.is_null() {
-        return (*parser)
-            .m_eventEndPtr
-            .wrapping_offset_from((*parser).m_eventPtr) as c_int;
+        return ((*parser).m_eventEndPtr as isize
+            - ((*parser).m_eventPtr) as isize) as c_int;
     }
     0
 }
@@ -3111,14 +3106,13 @@ pub unsafe extern "C" fn XML_GetInputContext(
     }
     if !(*parser).m_eventPtr.is_null() && !(*parser).m_buffer.is_null() {
         if !offset.is_null() {
-            *offset = (*parser)
-                .m_eventPtr
-                .wrapping_offset_from((*parser).m_buffer) as c_int
+            *offset = ((*parser)
+                .m_eventPtr as isize
+                 - ((*parser).m_buffer as isize)) as c_int
         }
         if !size.is_null() {
-            *size = (*parser)
-                .m_bufferEnd
-                .wrapping_offset_from((*parser).m_buffer) as c_int
+            *size = ((*parser).m_bufferEnd as isize
+                - ((*parser).m_buffer as isize)) as c_int
         }
         return (*parser).m_buffer;
     }
@@ -3443,7 +3437,7 @@ impl XML_ParserStruct {
             bufSize = (nameLen as c_ulong).wrapping_add(
                 round_up(tag.rawNameLength as usize, mem::size_of::<XML_Char>()) as c_ulong,
             ) as c_int;
-            if bufSize as c_long > tag.bufEnd.wrapping_offset_from(tag.buf) as c_long {
+            if bufSize as c_long > (tag.bufEnd as isize - (tag.buf as isize)) as c_long {
                 let mut temp = REALLOC!(tag.buf => [c_char; bufSize]);
                 if temp.is_null() {
                     return false;
@@ -3461,8 +3455,8 @@ impl XML_ParserStruct {
                     tag.name.localPart = (temp).offset(
                         tag
                             .name
-                            .localPart
-                            .wrapping_offset_from(tag.buf as *const XML_Char),
+                            .localPart as isize
+                            - (tag.buf as *const XML_Char as isize),
                     ) as *const XML_Char
                 } /* XmlContentTok doesn't always set the last arg */
                 tag.buf = temp;
@@ -3868,13 +3862,13 @@ impl XML_ParserStruct {
                             &mut fromBuf,
                             &mut to_buf,
                         );
-                        convLen = to_buf.as_ptr().wrapping_offset_from(tag.buf as *mut XML_Char).try_into().unwrap();
+                        convLen = (to_buf.as_ptr() as isize - (tag.buf as *mut XML_Char as isize)).try_into().unwrap();
                         if fromBuf.is_empty() || convert_res == super::xmltok::XML_Convert_Result::INPUT_INCOMPLETE
                         {
                             tag.name.strLen = convLen;
                             break;
                         } else {
-                            bufSize = (tag.bufEnd.wrapping_offset_from(tag.buf) as c_int) << 1;
+                            bufSize = ((tag.bufEnd as isize - (tag.buf as isize)) as c_int) << 1;
                             let mut temp = REALLOC!(tag.buf => [c_char; bufSize]);
                             if temp.is_null() {
                                 return XML_Error::NO_MEMORY;
@@ -7054,7 +7048,7 @@ impl XML_ParserStruct {
         }
         if result == XML_Error::NONE {
             if text_buf.end() != next && self.m_parsingStatus.parsing == XML_Parsing::SUSPENDED {
-                (*entity).processed = next.wrapping_offset_from(text_buf.as_ptr()) as i32;
+                (*entity).processed = (next as isize - (text_buf.as_ptr() as isize)) as i32;
                 self.m_processor = Some(internalEntityProcessor as Processor)
             } else {
                 (*entity).open = false;
@@ -7137,7 +7131,7 @@ unsafe extern "C" fn internalEntityProcessor(
     } else {
         if text_buf.end() != next && (*parser).m_parsingStatus.parsing == XML_Parsing::SUSPENDED {
             (*entity).processed =
-                next.wrapping_offset_from((*entity).textPtr as *mut c_char) as c_int;
+                (next as isize - ((*entity).textPtr as *mut c_char as isize)) as c_int;
             return result;
         } else {
             (*entity).open = false;
@@ -7767,7 +7761,7 @@ unsafe extern "C" fn reportDefault(
 
             let defaultRan = (*parser).m_handlers.default(
                 (*parser).m_dataBuf,
-                data_buf.as_ptr().wrapping_offset_from((*parser).m_dataBuf).try_into().unwrap(),
+                (data_buf.as_ptr() as isize - ((*parser).m_dataBuf as isize)).try_into().unwrap(),
             );
 
             // Previously unwrapped an Option

--- a/src/lib/xmltok_impl.rs
+++ b/src/lib/xmltok_impl.rs
@@ -1757,7 +1757,7 @@ impl<T: XmlEncodingImpl+XmlTokImpl> XmlEncoding for T {
                     ptr = ptr.offset(self.MINBPC())
                 }
                 _ => {
-                    return (ptr as isize) - (start as isize) as libc::c_long as
+                    return ((ptr as isize) - (start as isize)) as libc::c_long as
                                libc::c_int
                 }
             }

--- a/src/lib/xmltok_impl.rs
+++ b/src/lib/xmltok_impl.rs
@@ -1757,7 +1757,7 @@ impl<T: XmlEncodingImpl+XmlTokImpl> XmlEncoding for T {
                     ptr = ptr.offset(self.MINBPC())
                 }
                 _ => {
-                    return ptr.wrapping_offset_from(start) as libc::c_long as
+                    return (ptr as isize) - (start as isize) as libc::c_long as
                                libc::c_int
                 }
             }

--- a/src/tests/benchmark.rs
+++ b/src/tests/benchmark.rs
@@ -43,7 +43,6 @@
 #![feature(
     const_raw_ptr_to_usize_cast,
     main,
-    ptr_wrapping_offset_from,
     register_tool
 )]
 
@@ -158,7 +157,7 @@ unsafe fn main_0(mut argc: c_int, mut argv: *mut *mut c_char) -> c_int {
         tstart = clock();
         loop {
             let mut parseBufferSize: c_int =
-                XMLBufEnd.wrapping_offset_from(XMLBufPtr) as c_long as c_int;
+                XMLBufEnd as isize - (XMLBufPtr as isize) as c_long as c_int;
             if parseBufferSize <= bufferSize {
                 isFinal = 1 as c_int
             } else {

--- a/src/tests/benchmark.rs
+++ b/src/tests/benchmark.rs
@@ -157,7 +157,7 @@ unsafe fn main_0(mut argc: c_int, mut argv: *mut *mut c_char) -> c_int {
         tstart = clock();
         loop {
             let mut parseBufferSize: c_int =
-                XMLBufEnd as isize - (XMLBufPtr as isize) as c_long as c_int;
+                (XMLBufEnd as isize - (XMLBufPtr as isize)) as c_long as c_int;
             if parseBufferSize <= bufferSize {
                 isFinal = 1 as c_int
             } else {

--- a/src/tests/runtests.rs
+++ b/src/tests/runtests.rs
@@ -44,7 +44,6 @@
     const_raw_ptr_to_usize_cast,
     label_break_value,
     main,
-    ptr_wrapping_offset_from,
     register_tool
 )]
 
@@ -1336,7 +1335,7 @@ unsafe extern "C" fn test_utf8_auto_align() {
         let mut buf = ExpatBufRef::new(cases[i as usize].input, fromLim);
         _INTERNAL_trim_to_complete_utf8_characters(&mut buf);
         fromLim = buf.end();
-        actualMovementInChars = fromLim.wrapping_offset_from(fromLimInitially);
+        actualMovementInChars = fromLim as isize - (fromLimInitially as isize);
         if actualMovementInChars != cases[i as usize].expectedMovementInChars {
             let mut j: size_t = 0;
             success = false_0 != 0;

--- a/src/xmlwf/xmlwf.rs
+++ b/src/xmlwf/xmlwf.rs
@@ -12,7 +12,6 @@
     const_raw_ptr_to_usize_cast,
     label_break_value,
     main,
-    ptr_wrapping_offset_from,
     register_tool
 )]
 
@@ -171,7 +170,7 @@ unsafe extern "C" fn startElement(
     while !(*p).is_null() {
         p = p.offset(1)
     }
-    nAtts = (p.wrapping_offset_from(atts) as c_long >> 1) as c_int;
+    nAtts = ((p as isize) - (atts as isize) as c_long >> 1) as c_int;
     if nAtts > 1 {
         qsort(
             atts as *mut c_void,
@@ -236,7 +235,7 @@ unsafe extern "C" fn startElementNS(
     while !(*p).is_null() {
         p = p.offset(1)
     }
-    nAtts = (p.wrapping_offset_from(atts) as c_long >> 1) as c_int;
+    nAtts = (p as isize - (atts as isize) as c_long >> 1) as c_int;
     if nAtts > 1 {
         qsort(
             atts as *mut c_void,
@@ -921,7 +920,7 @@ unsafe extern "C" fn unknownEncoding(
             return 0i32;
         }
         cp *= 10;
-        cp += s.wrapping_offset_from(digits.as_ptr()) as c_int;
+        cp += (s as isize) - (digits.as_ptr() as isize) as c_int;
         if cp >= 0x10000 {
             return 0i32;
         }

--- a/src/xmlwf/xmlwf.rs
+++ b/src/xmlwf/xmlwf.rs
@@ -170,7 +170,7 @@ unsafe extern "C" fn startElement(
     while !(*p).is_null() {
         p = p.offset(1)
     }
-    nAtts = ((p as isize) - (atts as isize) as c_long >> 1) as c_int;
+    nAtts = (((p as isize) - (atts as isize)) as c_long >> 1) as c_int;
     if nAtts > 1 {
         qsort(
             atts as *mut c_void,
@@ -235,7 +235,7 @@ unsafe extern "C" fn startElementNS(
     while !(*p).is_null() {
         p = p.offset(1)
     }
-    nAtts = (p as isize - (atts as isize) as c_long >> 1) as c_int;
+    nAtts = ((p as isize - (atts as isize)) as c_long >> 1) as c_int;
     if nAtts > 1 {
         qsort(
             atts as *mut c_void,
@@ -920,7 +920,7 @@ unsafe extern "C" fn unknownEncoding(
             return 0i32;
         }
         cp *= 10;
-        cp += (s as isize) - (digits.as_ptr() as isize) as c_int;
+        cp += ((s as isize) - (digits.as_ptr() as isize)) as c_int;
         if cp >= 0x10000 {
             return 0i32;
         }


### PR DESCRIPTION
This is poorly formatted, and I don't even know if this actually works. However, the `ptr_wrapping_offset_from` feature was [deprecated](https://github.com/rust-lang/rust/pull/73580) in June and [completely removed](https://github.com/rust-lang/rust/commit/7ad4369ba695b37b6f758ef94ff28597e840bc32) in August.

Let me know if I have to rebase this against a different branch.